### PR TITLE
fix: create jjj metadata branch from root() instead of @

### DIFF
--- a/src/commands/insights.rs
+++ b/src/commands/insights.rs
@@ -33,10 +33,13 @@ pub fn execute(ctx: &CommandContext, json: bool) -> Result<()> {
 
     if events.is_empty() {
         if json {
-            println!("{}", serde_json::to_string_pretty(&serde_json::json!({
-                "total_events": 0,
-                "message": "No events recorded yet"
-            }))?);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "total_events": 0,
+                    "message": "No events recorded yet"
+                }))?
+            );
         } else {
             println!("No events recorded yet.");
         }

--- a/src/commands/problem.rs
+++ b/src/commands/problem.rs
@@ -19,7 +19,9 @@ pub fn execute(ctx: &CommandContext, action: ProblemAction) -> Result<()> {
             force,
             context,
             tags,
-        } => new_problem(ctx, title, priority, parent, milestone, force, context, tags),
+        } => new_problem(
+            ctx, title, priority, parent, milestone, force, context, tags,
+        ),
         ProblemAction::List {
             status,
             tree,
@@ -50,7 +52,9 @@ pub fn execute(ctx: &CommandContext, action: ProblemAction) -> Result<()> {
             add_tag,
             remove_tag,
             set_tags,
-        } => edit_problem(ctx, problem_id, title, status, priority, parent, add_tag, remove_tag, set_tags),
+        } => edit_problem(
+            ctx, problem_id, title, status, priority, parent, add_tag, remove_tag, set_tags,
+        ),
         ProblemAction::Tree { problem_id } => show_tree(ctx, problem_id),
         ProblemAction::Solve {
             problem_id,
@@ -170,7 +174,11 @@ fn new_problem(
 
         // Set tags (trim, dedup, sort)
         if !tags.is_empty() {
-            let mut t: Vec<String> = tags.iter().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+            let mut t: Vec<String> = tags
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
             t.sort();
             t.dedup();
             problem.tags = t;

--- a/src/commands/solution.rs
+++ b/src/commands/solution.rs
@@ -48,7 +48,15 @@ pub fn execute(ctx: &CommandContext, action: SolutionAction) -> Result<()> {
             add_tag,
             remove_tag,
             set_tags,
-        } => edit_solution(ctx, solution_id, title, status, add_tag, remove_tag, set_tags),
+        } => edit_solution(
+            ctx,
+            solution_id,
+            title,
+            status,
+            add_tag,
+            remove_tag,
+            set_tags,
+        ),
         SolutionAction::Attach { solution_id, force } => attach_change(ctx, solution_id, force),
         SolutionAction::Detach {
             solution_id,
@@ -189,7 +197,11 @@ fn new_solution(
 
         // Set tags (trim, dedup, sort)
         if !tags.is_empty() {
-            let mut t: Vec<String> = tags.iter().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+            let mut t: Vec<String> = tags
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
             t.sort();
             t.dedup();
             solution.tags = t;
@@ -496,7 +508,11 @@ fn edit_solution(
         }
 
         if let Some(ref tags) = set_tags {
-            let mut t: Vec<String> = tags.iter().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+            let mut t: Vec<String> = tags
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
             t.sort();
             t.dedup();
             solution.tags = t;
@@ -504,7 +520,12 @@ fn edit_solution(
 
         if let Some(ref tag) = add_tag {
             let tag = tag.trim().to_string();
-            if !tag.is_empty() && !solution.tags.iter().any(|t| t.to_lowercase() == tag.to_lowercase()) {
+            if !tag.is_empty()
+                && !solution
+                    .tags
+                    .iter()
+                    .any(|t| t.to_lowercase() == tag.to_lowercase())
+            {
                 solution.tags.push(tag);
                 solution.tags.sort();
             }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -221,11 +221,7 @@ pub fn execute(
                     .iter()
                     .map(|(_, title)| title.as_str())
                     .collect();
-                println!(
-                    "  {} — {}",
-                    overlap.file.display(),
-                    sol_names.join(", ")
-                );
+                println!("  {} — {}", overlap.file.display(), sol_names.join(", "));
             }
         }
     }

--- a/src/db/entities.rs
+++ b/src/db/entities.rs
@@ -55,8 +55,7 @@ fn parse_enum<T: std::str::FromStr + Default>(s: &str, kind: &str, default_name:
 
 /// Insert or update a problem in the database.
 pub fn upsert_problem(conn: &Connection, problem: &Problem) -> SqliteResult<()> {
-    let tags_json =
-        serde_json::to_string(&problem.tags).unwrap_or_else(|_| "[]".to_string());
+    let tags_json = serde_json::to_string(&problem.tags).unwrap_or_else(|_| "[]".to_string());
 
     conn.execute(
         "INSERT OR REPLACE INTO problems (
@@ -162,8 +161,7 @@ fn row_to_problem(row: &rusqlite::Row) -> SqliteResult<Problem> {
 pub fn upsert_solution(conn: &Connection, solution: &Solution) -> SqliteResult<()> {
     let change_ids_json =
         serde_json::to_string(&solution.change_ids).unwrap_or_else(|_| "[]".to_string());
-    let tags_json =
-        serde_json::to_string(&solution.tags).unwrap_or_else(|_| "[]".to_string());
+    let tags_json = serde_json::to_string(&solution.tags).unwrap_or_else(|_| "[]".to_string());
 
     conn.execute(
         "INSERT OR REPLACE INTO solutions (

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -95,7 +95,7 @@ pub fn all_migrations() -> Vec<Migration> {
             up: |conn| {
                 conn.execute_batch(
                     "ALTER TABLE problems ADD COLUMN tags TEXT DEFAULT '[]';
-                     ALTER TABLE solutions ADD COLUMN tags TEXT DEFAULT '[]';"
+                     ALTER TABLE solutions ADD COLUMN tags TEXT DEFAULT '[]';",
                 )?;
                 Ok(())
             },

--- a/src/db/sync.rs
+++ b/src/db/sync.rs
@@ -115,7 +115,12 @@ pub fn rebuild_fts(db: &Database) -> Result<()> {
     // Index problems
     let problems = list_problems(conn)?;
     for problem in &problems {
-        let body = format!("{}\n{}\n{}", problem.description, problem.context, problem.tags.join(" "));
+        let body = format!(
+            "{}\n{}\n{}",
+            problem.description,
+            problem.context,
+            problem.tags.join(" ")
+        );
         conn.execute(
             "INSERT INTO fts (entity_type, entity_id, title, body) VALUES (?1, ?2, ?3, ?4)",
             params!["problem", &problem.id, &problem.title, &body],
@@ -125,7 +130,12 @@ pub fn rebuild_fts(db: &Database) -> Result<()> {
     // Index solutions
     let solutions = list_solutions(conn)?;
     for solution in &solutions {
-        let body = format!("{}\n{}\n{}", solution.approach, solution.tradeoffs, solution.tags.join(" "));
+        let body = format!(
+            "{}\n{}\n{}",
+            solution.approach,
+            solution.tradeoffs,
+            solution.tags.join(" ")
+        );
         conn.execute(
             "INSERT INTO fts (entity_type, entity_id, title, body) VALUES (?1, ?2, ?3, ?4)",
             params!["solution", &solution.id, &solution.title, &body],

--- a/src/jj.rs
+++ b/src/jj.rs
@@ -125,6 +125,13 @@ impl JjClient {
         self.current_change_id()
     }
 
+    /// Create a new empty change whose parent is root(), producing an orphan branch.
+    pub fn new_orphan_change(&self, message: &str) -> Result<String> {
+        self.execute(&["new", "-r", "root()"])?;
+        self.describe(message)?;
+        self.current_change_id()
+    }
+
     /// Set the description of the current change
     pub fn describe(&self, message: &str) -> Result<()> {
         self.execute(&["describe", "-m", message])?;

--- a/src/models/problem.rs
+++ b/src/models/problem.rs
@@ -481,11 +481,22 @@ mod tests {
         let mut p = Problem::new("P-1".to_string(), "Test".to_string());
         assert!(p.tags.is_empty());
 
-        p.tags = vec!["backend".to_string(), "auth".to_string(), "size:L".to_string()];
+        p.tags = vec![
+            "backend".to_string(),
+            "auth".to_string(),
+            "size:L".to_string(),
+        ];
 
         // Round-trip through frontmatter
         let fm = ProblemFrontmatter::from(&p);
-        assert_eq!(fm.tags, vec!["backend".to_string(), "auth".to_string(), "size:L".to_string()]);
+        assert_eq!(
+            fm.tags,
+            vec![
+                "backend".to_string(),
+                "auth".to_string(),
+                "size:L".to_string()
+            ]
+        );
 
         // Verify serde round-trip
         let yaml = serde_yml::to_string(&fm).unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -210,8 +210,8 @@ impl MetadataStore {
             ));
         }
 
-        // Create an empty orphan root
-        let change_id = self.jj_client.new_empty_change("Initialize jjj metadata")?;
+        // Create an empty orphan root descending from root()
+        let change_id = self.jj_client.new_orphan_change("Initialize jjj metadata")?;
 
         // Create the bookmark
         self.jj_client.create_bookmark(META_BOOKMARK, &change_id)?;
@@ -245,7 +245,7 @@ impl MetadataStore {
         if !self.meta_path.exists() {
             // Auto-initialize if the jjj bookmark has never been created.
             if !self.jj_client.bookmark_exists(META_BOOKMARK)? {
-                let change_id = self.jj_client.new_empty_change("Initialize jjj metadata")?;
+                let change_id = self.jj_client.new_orphan_change("Initialize jjj metadata")?;
                 self.jj_client.create_bookmark(META_BOOKMARK, &change_id)?;
             }
             let meta_path_str = self

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -211,7 +211,9 @@ impl MetadataStore {
         }
 
         // Create an empty orphan root descending from root()
-        let change_id = self.jj_client.new_orphan_change("Initialize jjj metadata")?;
+        let change_id = self
+            .jj_client
+            .new_orphan_change("Initialize jjj metadata")?;
 
         // Create the bookmark
         self.jj_client.create_bookmark(META_BOOKMARK, &change_id)?;
@@ -245,7 +247,9 @@ impl MetadataStore {
         if !self.meta_path.exists() {
             // Auto-initialize if the jjj bookmark has never been created.
             if !self.jj_client.bookmark_exists(META_BOOKMARK)? {
-                let change_id = self.jj_client.new_orphan_change("Initialize jjj metadata")?;
+                let change_id = self
+                    .jj_client
+                    .new_orphan_change("Initialize jjj metadata")?;
                 self.jj_client.create_bookmark(META_BOOKMARK, &change_id)?;
             }
             let meta_path_str = self

--- a/src/storage/solutions.rs
+++ b/src/storage/solutions.rs
@@ -69,7 +69,12 @@ impl MetadataStore {
         let db_path = self.jj_client.repo_root().join(".jj").join("jjj.db");
         if db_path.exists() {
             if let Ok(db) = crate::db::schema::Database::open(&db_path) {
-                let fts_body = format!("{}\n{}\n{}", solution.approach, solution.tradeoffs, solution.tags.join(" "));
+                let fts_body = format!(
+                    "{}\n{}\n{}",
+                    solution.approach,
+                    solution.tradeoffs,
+                    solution.tags.join(" ")
+                );
                 let _ = crate::db::sync::update_fts_entry(
                     db.conn(),
                     "solution",

--- a/src/tui/app/actions.rs
+++ b/src/tui/app/actions.rs
@@ -253,14 +253,12 @@ impl App {
 
         match entity_type {
             EntityType::Problem => {
-                self.store.with_metadata(
-                    &format!("Update problem tags: {}", entity_id),
-                    || {
+                self.store
+                    .with_metadata(&format!("Update problem tags: {}", entity_id), || {
                         let mut problem = self.store.load_problem(entity_id)?;
                         problem.tags = tags.clone();
                         self.store.save_problem(&problem)
-                    },
-                )?;
+                    })?;
             }
             EntityType::Solution => {
                 self.store.with_metadata(
@@ -681,14 +679,12 @@ impl App {
 
         if let Some(item) = self.cache.tree_items.get(self.ui.tree_index) {
             let (entity_type, entity_id, title) = match &item.node {
-                TreeNode::Critique { id, title, .. } => ("critique".to_string(), id.clone(), title.clone()),
+                TreeNode::Critique { id, title, .. } => {
+                    ("critique".to_string(), id.clone(), title.clone())
+                }
                 TreeNode::Solution { id, title, .. } => {
                     // Block if has critiques
-                    let has_critiques = self
-                        .data
-                        .critiques
-                        .iter()
-                        .any(|c| c.solution_id == *id);
+                    let has_critiques = self.data.critiques.iter().any(|c| c.solution_id == *id);
                     if has_critiques {
                         self.show_flash("Delete critiques first");
                         return Ok(());
@@ -697,11 +693,7 @@ impl App {
                 }
                 TreeNode::Problem { id, title, .. } => {
                     // Block if has solutions
-                    let has_solutions = self
-                        .data
-                        .solutions
-                        .iter()
-                        .any(|s| s.problem_id == *id);
+                    let has_solutions = self.data.solutions.iter().any(|s| s.problem_id == *id);
                     if has_solutions {
                         self.show_flash("Delete solutions first");
                         return Ok(());

--- a/src/tui/app/navigation.rs
+++ b/src/tui/app/navigation.rs
@@ -317,7 +317,10 @@ impl App {
                     )
                 }
                 TreeNode::Critique { id, .. } => {
-                    format!("{}: [a]ddress [d]ismiss [e]dit [E]dit in $EDITOR [x] delete", id)
+                    format!(
+                        "{}: [a]ddress [d]ismiss [e]dit [E]dit in $EDITOR [x] delete",
+                        id
+                    )
                 }
             }
         } else {

--- a/tests/command_insights_test.rs
+++ b/tests/command_insights_test.rs
@@ -13,7 +13,13 @@ fn test_insights_basic() {
     run_jjj_success(&dir, &["problem", "new", "Test Problem"]);
     run_jjj_success(
         &dir,
-        &["solution", "new", "Test Solution", "--problem", "Test Problem"],
+        &[
+            "solution",
+            "new",
+            "Test Solution",
+            "--problem",
+            "Test Problem",
+        ],
     );
 
     let stdout = run_jjj_success(&dir, &["insights"]);
@@ -74,10 +80,7 @@ fn test_insights_with_data() {
         &["solution", "new", "Solution", "--problem", "Problem"],
     );
     run_jjj_success(&dir, &["solution", "submit", "Solution"]);
-    run_jjj_success(
-        &dir,
-        &["solution", "approve", "Solution", "--no-rationale"],
-    );
+    run_jjj_success(&dir, &["solution", "approve", "Solution", "--no-rationale"]);
 
     let stdout = run_jjj_success(&dir, &["insights", "--json"]);
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("Failed to parse JSON");

--- a/tests/command_next_test.rs
+++ b/tests/command_next_test.rs
@@ -57,8 +57,7 @@ fn test_next_claim() {
 
     // Verify assignment by checking the problem
     let show_stdout = run_jjj_success(&dir, &["problem", "show", "Claimable", "--json"]);
-    let json: serde_json::Value =
-        serde_json::from_str(&show_stdout).expect("Failed to parse JSON");
+    let json: serde_json::Value = serde_json::from_str(&show_stdout).expect("Failed to parse JSON");
     assert!(
         json["assignee"].is_string(),
         "Expected assignee to be set after claim: {:?}",

--- a/tests/command_problem_test.rs
+++ b/tests/command_problem_test.rs
@@ -387,7 +387,10 @@ fn test_problem_new_with_tags() {
     }
     let dir = setup_test_repo();
 
-    run_jjj_success(&dir, &["problem", "new", "Tagged Problem", "--tags", "backend,auth"]);
+    run_jjj_success(
+        &dir,
+        &["problem", "new", "Tagged Problem", "--tags", "backend,auth"],
+    );
 
     let stdout = run_jjj_success(&dir, &["problem", "show", "Tagged Problem"]);
     assert!(
@@ -405,7 +408,10 @@ fn test_problem_edit_add_tag() {
     let dir = setup_test_repo();
 
     run_jjj_success(&dir, &["problem", "new", "Tag Edit Test"]);
-    run_jjj_success(&dir, &["problem", "edit", "Tag Edit Test", "--add-tag", "backend"]);
+    run_jjj_success(
+        &dir,
+        &["problem", "edit", "Tag Edit Test", "--add-tag", "backend"],
+    );
 
     let stdout = run_jjj_success(&dir, &["problem", "show", "Tag Edit Test"]);
     assert!(
@@ -415,7 +421,16 @@ fn test_problem_edit_add_tag() {
     );
 
     // Remove the tag
-    run_jjj_success(&dir, &["problem", "edit", "Tag Edit Test", "--remove-tag", "backend"]);
+    run_jjj_success(
+        &dir,
+        &[
+            "problem",
+            "edit",
+            "Tag Edit Test",
+            "--remove-tag",
+            "backend",
+        ],
+    );
     let stdout = run_jjj_success(&dir, &["problem", "show", "Tag Edit Test"]);
     assert!(
         !stdout.contains("Tags:"),
@@ -457,13 +472,37 @@ fn test_problem_edit_set_tags() {
     run_jjj_success(&dir, &["problem", "new", "Set Tags Test", "--tags", "old"]);
 
     // Replace all tags atomically
-    run_jjj_success(&dir, &["problem", "edit", "Set Tags Test", "--set-tags", "alpha,beta"]);
+    run_jjj_success(
+        &dir,
+        &[
+            "problem",
+            "edit",
+            "Set Tags Test",
+            "--set-tags",
+            "alpha,beta",
+        ],
+    );
     let stdout = run_jjj_success(&dir, &["problem", "show", "Set Tags Test"]);
-    assert!(stdout.contains("alpha") && stdout.contains("beta"), "Expected new tags: {}", stdout);
-    assert!(!stdout.contains("old"), "Expected old tag removed: {}", stdout);
+    assert!(
+        stdout.contains("alpha") && stdout.contains("beta"),
+        "Expected new tags: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("old"),
+        "Expected old tag removed: {}",
+        stdout
+    );
 
     // Clear all tags with empty --set-tags
-    run_jjj_success(&dir, &["problem", "edit", "Set Tags Test", "--set-tags", ""]);
+    run_jjj_success(
+        &dir,
+        &["problem", "edit", "Set Tags Test", "--set-tags", ""],
+    );
     let stdout = run_jjj_success(&dir, &["problem", "show", "Set Tags Test"]);
-    assert!(!stdout.contains("Tags:"), "Expected no tags after clear: {}", stdout);
+    assert!(
+        !stdout.contains("Tags:"),
+        "Expected no tags after clear: {}",
+        stdout
+    );
 }

--- a/tests/command_solution_test.rs
+++ b/tests/command_solution_test.rs
@@ -636,17 +636,39 @@ fn test_solution_edit_set_tags() {
     run_jjj_success(&dir, &["problem", "new", "Problem"]);
     run_jjj_success(
         &dir,
-        &["solution", "new", "Set Tags Sol", "--problem", "Problem", "--tags", "old"],
+        &[
+            "solution",
+            "new",
+            "Set Tags Sol",
+            "--problem",
+            "Problem",
+            "--tags",
+            "old",
+        ],
     );
 
     // Replace all tags atomically
     run_jjj_success(
         &dir,
-        &["solution", "edit", "Set Tags Sol", "--set-tags", "alpha,beta"],
+        &[
+            "solution",
+            "edit",
+            "Set Tags Sol",
+            "--set-tags",
+            "alpha,beta",
+        ],
     );
     let stdout = run_jjj_success(&dir, &["solution", "show", "Set Tags Sol"]);
-    assert!(stdout.contains("alpha") && stdout.contains("beta"), "Expected new tags: {}", stdout);
-    assert!(!stdout.contains("old"), "Expected old tag removed: {}", stdout);
+    assert!(
+        stdout.contains("alpha") && stdout.contains("beta"),
+        "Expected new tags: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("old"),
+        "Expected old tag removed: {}",
+        stdout
+    );
 
     // Clear all tags with empty --set-tags
     run_jjj_success(
@@ -654,5 +676,9 @@ fn test_solution_edit_set_tags() {
         &["solution", "edit", "Set Tags Sol", "--set-tags", ""],
     );
     let stdout = run_jjj_success(&dir, &["solution", "show", "Set Tags Sol"]);
-    assert!(!stdout.contains("Tags:"), "Expected no tags after clear: {}", stdout);
+    assert!(
+        !stdout.contains("Tags:"),
+        "Expected no tags after clear: {}",
+        stdout
+    );
 }

--- a/tests/command_status_test.rs
+++ b/tests/command_status_test.rs
@@ -231,7 +231,10 @@ fn test_status_priority_sorting() {
 
     // Create problems with different priorities
     run_jjj_success(&dir, &["problem", "new", "Low", "--priority", "low"]);
-    run_jjj_success(&dir, &["problem", "new", "Critical", "--priority", "critical"]);
+    run_jjj_success(
+        &dir,
+        &["problem", "new", "Critical", "--priority", "critical"],
+    );
     run_jjj_success(&dir, &["problem", "new", "High", "--priority", "high"]);
 
     let stdout = run_jjj_success(&dir, &["status", "--json", "--all"]);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,75 @@
 mod test_helpers;
 use std::process::Command;
-use test_helpers::{jj_available, run_jjj, setup_test_repo};
+use test_helpers::{jj_available, jjj_binary, run_jjj, setup_test_repo};
+
+/// Regression test for https://github.com/doug/jjj/issues/1
+/// `jjj init` must create the metadata branch from root(), not on top of @.
+#[test]
+fn test_init_creates_orphan_from_root() {
+    if !jj_available() {
+        return;
+    }
+
+    let dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+
+    // Initialize a jj repo and make a real commit so @ is not at root
+    Command::new("jj")
+        .args(["git", "init"])
+        .current_dir(dir.path())
+        .output()
+        .expect("jj git init");
+    Command::new("jj")
+        .args(["config", "set", "--repo", "user.name", "Test User"])
+        .current_dir(dir.path())
+        .status()
+        .ok();
+    Command::new("jj")
+        .args(["config", "set", "--repo", "user.email", "test@example.com"])
+        .current_dir(dir.path())
+        .status()
+        .ok();
+
+    // Create a file and describe the change so @ has content
+    std::fs::write(dir.path().join("hello.txt"), "hello").unwrap();
+    Command::new("jj")
+        .args(["describe", "-m", "user commit"])
+        .current_dir(dir.path())
+        .output()
+        .expect("jj describe");
+
+    // Now run jjj init
+    let output = Command::new(jjj_binary())
+        .arg("init")
+        .current_dir(dir.path())
+        .output()
+        .expect("jjj init");
+    assert!(
+        output.status.success(),
+        "jjj init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify: the jjj bookmark's ancestor chain should include root() but
+    // should NOT include the "user commit" change.
+    let log_output = Command::new("jj")
+        .args([
+            "log",
+            "--no-graph",
+            "-r",
+            "ancestors(jjj)",
+            "-T",
+            r#"description ++ "\n""#,
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("jj log");
+    let log_stdout = String::from_utf8_lossy(&log_output.stdout);
+    assert!(
+        !log_stdout.contains("user commit"),
+        "jjj bookmark should NOT descend from @; got ancestors:\n{}",
+        log_stdout
+    );
+}
 
 #[test]
 fn test_init_and_create_problem_solution() {


### PR DESCRIPTION
## Summary
- `jjj init` was running `jj new` (which parents on `@`), causing the metadata branch to sit on top of user commits instead of being an independent orphan
- Changed to use `jj new -r root()` so the `jjj` bookmark descends from the root commit, fully isolated from project history
- Added regression test `test_init_creates_orphan_from_root` that verifies the jjj bookmark's ancestors don't include user commits
- Ran `cargo fmt` to fix pre-existing formatting issues

Fixes #1

## Test plan
- [x] New integration test `test_init_creates_orphan_from_root` passes
- [x] All 228 unit tests + all integration tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` clean (only pre-existing format string warnings)
- [x] Manual test: `jjj init` in a repo with existing commits creates bookmark from root()